### PR TITLE
feat(ui): add mouse button support and cursor interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to the **Glacex** UI toolkit will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### Added
+- **Dynamic Mouse Cursor Feedback**: Native OS cursor icon management via `winit::window::CursorIcon`:
+  - `Pointer` (Hand) cursor on [`Button`], [`Switch`], [`Checkbox`], [`RadioButton`], and [`ScrollView`] scrollbar thumbs.
+  - `Text` (I-beam) cursor on [`TextInput`] and [`TextArea`].
+  - `EwResize` (horizontal resize arrows) on [`Slider`] thumb and during active thumb dragging.
+  - Per-frame cursor state reset restoring `CursorIcon::Default` when hovering non-interactive regions.
+- **Floating Tooltip Overlay System**:
+  - Added `ui.show_tooltip(text)` and `ui.show_tooltip_at(text, position)`.
+  - Added fluent `.tooltip("...")` builder to [`Button`].
+  - Tooltips render on top of the scene with automatic viewport boundary clamping, dark elevated background, strong hairline border, drop shadow, and typography padding.
+- **Secondary & Middle Mouse Button Support**:
+  - Added input tracking for `MouseButton::Right` and `MouseButton::Middle` in event loop handling.
+  - New `Ui` methods: `mouse_right_pressed()`, `mouse_right_released()`, `mouse_right_pressed_this_frame()`, `mouse_right_released_this_frame()`, `mouse_middle_pressed()`, `mouse_middle_released()`, `mouse_middle_pressed_this_frame()`, and `mouse_middle_released_this_frame()`.
+- **Project Documentation & Guidelines**:
+  - Added comprehensive [`ROADMAP.md`](ROADMAP.md) detailing milestones from v0.1.0 to v1.0.0 LTS.
+  - Added [`CONTRIBUTING.md`](CONTRIBUTING.md) with guidelines for PRs, coding conventions, architecture patterns, and testing.
+
+### Fixed
+- **Slider UI Borrow Concurrency**: Fixed double mutable borrow of `*ui` in `Slider::arrange` using `take_widget_state` / `put_widget_state`.
+- **Demo Layout Borrow Checks**: Refactored `examples/demo.rs` and other examples to avoid holding overlapping mutable borrows across row/column macros and widget queries.
+
+---
+
+## [0.1.1] - 2026-09-04
+
+### Added
+- **Repository Metadata**: Added repository URL (`https://github.com/artemtsitronov/glacex`) and package configuration in `Cargo.toml`.
+- **Documentation**: Updated `README.md` with updated widget listings and architecture notes.
+
+---
+
+## [0.1.0] - 2026-09-03
+
+### Added
+- **Expanded Widget Suite**:
+  - [`Badge`]: Semantic status badges (`Default`, `Outline`, `Success`, `Warning`, `Error`).
+  - [`Card`]: Elevated surface container with padding, rounded corners, and drop shadows.
+  - [`Checkbox`]: Toggle checkbox with checked/hover/idle styles and state tracking.
+  - [`RadioButton`]: Group-aware single-selection radio controls.
+  - [`Switch`]: Compact animated toggle switch with pill thumb geometry.
+  - [`Slider`]: Continuous numerical range slider with draggable knob and active track fill.
+  - [`ProgressBar`]: Horizontal progress indicator.
+  - [`Divider`]: Horizontal and vertical layout separator rules.
+  - [`ScrollView`]: Dual-axis scroll container with draggable interactive scrollbar thumbs.
+  - [`TextArea`]: Multi-line text editor with line-aware cursor movement, scrolling, and selection.
+  - [`TextInput`]: Single-line text input with clipboard copy/paste, word jump, and cursor blinking.
+- **Modern Dark Theme (Linear / Vercel Aesthetic)**:
+  - Deep canvas (`#09090b`), surface colors (`#121216`, `#18181b`, `#202026`).
+  - Crisp electric indigo primary accents (`#4f46e5`, `#6366f1`).
+  - Subtle hairline borders and translucent drop shadows.
+- **Interactive State & Focus Management**:
+  - Stable widget focus IDs (`FocusId`).
+  - Tab navigation focus traversal (`advance_focus`).
+  - Native clipboard integration via `arboard`.
+  - Multi-click word and line selection in text controls.
+- **Rendering & Pipeline**:
+  - `wgpu` 30.0 GPU-accelerated rendering pipeline with WGSL SDF shaders for anti-aliased rounded boxes, borders, and blurs.
+  - Sub-pixel text rendering and layout with `glyphon` 0.12 and `swash`.
+  - Flexbox layout engine powered by `taffy` 0.13.
+  - Macro-based declarative row and column building (`row!`, `column!`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to Glacex
+
+Thanks for your interest in contributing to Glacex! This document outlines the process and guidelines.
+
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Install the Rust toolchain (stable, edition 2024, minimum `rustc 1.85`).
+3. Run `cargo check` to verify the build compiles.
+
+## Development Workflow
+
+### Code Style
+
+- Run `cargo fmt` and `cargo fmt --all` before committing.
+- Run `cargo clippy --all-targets --all-features -- -D warnings` and fix any warnings.
+- Follow standard Rust naming conventions and idioms.
+
+### Building & Testing
+
+```sh
+cargo fmt && cargo fmt --all
+cargo check --workspace
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+```
+
+All four must pass before submitting a PR.
+
+### Commit Messages
+
+- Use clear, descriptive commit messages.
+- Prefix with a category when appropriate: `fix:`, `feat:`, `refactor:`, `docs:`, `chore:`.
+
+## Submitting a Pull Request
+
+1. Create a feature branch from `main`.
+2. Make your changes following the guidelines above.
+3. Ensure CI checks pass (fmt, clippy, tests).
+4. Open a pull request with a clear description of what changed and why.
+5. Reference any related issues.
+
+### PR Guidelines
+
+- Keep PRs focused — one logical change per PR.
+- All new public APIs must include rustdoc comments.
+- Add examples or tests for new functionality when practical.
+- Breaking changes should be clearly noted in the PR description.
+
+## Reporting Issues
+
+- Use GitHub Issues for bug reports and feature requests.
+- Include reproduction steps, expected vs. actual behavior, and your environment (OS, Rust version, GPU).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -63,26 +63,30 @@ impl Widget for AppState {
         // Left Panel: Metric Counter & Action Buttons
         let mut counter_header = Label::new("METRICS");
         let mut counter_val = Label::new(format!("Events Processed: {}", self.count));
-        let mut primary_btn = Button::new("Deploy Trigger").style(ButtonStyle {
-            fill: brand_gradient,
-            hover_fill: Fill::Solid(Theme::ACTIVE_HOVER),
-            pressed_fill: Fill::Solid(Theme::ACTIVE),
-            border_width: 1.0,
-            border_color: Color::WHITE.with_alpha(0.2),
-            corner_radius: 8.0,
-            shadow: Some(ShadowStyle {
-                color: Theme::ACTIVE.with_alpha(0.4),
-                blur_radius: 12.0,
-                offset: [0.0, 3.0],
-            }),
-            sharp: false,
-        });
+        let mut primary_btn = Button::new("Deploy Trigger")
+            .tooltip("Triggers a simulated deployment event")
+            .style(ButtonStyle {
+                fill: brand_gradient,
+                hover_fill: Fill::Solid(Theme::ACTIVE_HOVER),
+                pressed_fill: Fill::Solid(Theme::ACTIVE),
+                border_width: 1.0,
+                border_color: Color::WHITE.with_alpha(0.2),
+                corner_radius: 8.0,
+                shadow: Some(ShadowStyle {
+                    color: Theme::ACTIVE.with_alpha(0.4),
+                    blur_radius: 12.0,
+                    offset: [0.0, 3.0],
+                }),
+                sharp: false,
+            });
 
-        let mut reset_btn = Button::new("Reset Counter").style(ButtonStyle {
-            fill: Fill::Solid(Theme::SURFACE_SUBTLE),
-            hover_fill: Fill::Solid(Theme::HOVERED),
-            pressed_fill: Fill::Solid(Theme::ACTIVE),
-            border_width: 1.0,
+        let mut reset_btn = Button::new("Reset Counter")
+            .tooltip("Resets processed events to zero")
+            .style(ButtonStyle {
+                fill: Fill::Solid(Theme::SURFACE_SUBTLE),
+                hover_fill: Fill::Solid(Theme::HOVERED),
+                pressed_fill: Fill::Solid(Theme::ACTIVE),
+                border_width: 1.0,
             border_color: Theme::BORDER,
             corner_radius: 8.0,
             shadow: None,

--- a/src/button.rs
+++ b/src/button.rs
@@ -7,6 +7,7 @@ use crate::theme::Theme;
 use crate::ui::Ui;
 use crate::widget::{Measurable, Widget};
 use std::default::Default;
+use winit::window::CursorIcon;
 
 pub type ButtonResponse = Interaction;
 
@@ -41,6 +42,7 @@ pub struct Button {
     label: String,
     interaction: Interaction,
     style: Option<ButtonStyle>,
+    tooltip: Option<String>,
 }
 
 impl Button {
@@ -49,11 +51,17 @@ impl Button {
             label: label.into(),
             interaction: Interaction::default(),
             style: None,
+            tooltip: None,
         }
     }
 
     pub fn style(mut self, style: ButtonStyle) -> Self {
         self.style = Some(style);
+        self
+    }
+
+    pub fn tooltip(mut self, tooltip: impl Into<String>) -> Self {
+        self.tooltip = Some(tooltip.into());
         self
     }
 
@@ -126,6 +134,13 @@ impl Measurable for Button {
             position[1] + size[1],
         ];
         ui.draw_text(&self.label, text_position, clip_rect);
+
+        if interaction.hovered {
+            ui.set_cursor_icon(CursorIcon::Pointer);
+            if let Some(tooltip) = &self.tooltip {
+                ui.show_tooltip(tooltip.clone());
+            }
+        }
 
         interaction
     }

--- a/src/checkbox.rs
+++ b/src/checkbox.rs
@@ -5,6 +5,7 @@ use crate::shadow::{ShadowStyle, draw_shadow};
 use crate::theme::Theme;
 use crate::ui::Ui;
 use crate::widget::{Measurable, Widget};
+use winit::window::CursorIcon;
 
 #[derive(Default)]
 pub struct CheckboxState {
@@ -92,6 +93,10 @@ impl Measurable for Checkbox {
 
         let interaction = Interaction::update(position, size, style.corner_radius, ui);
         self.interaction = interaction;
+
+        if interaction.hovered {
+            ui.set_cursor_icon(CursorIcon::Pointer);
+        }
 
         let state = ui.widget_state::<CheckboxState>(&self.id);
         if interaction.clicked {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,9 +174,20 @@ impl<W: Widget> ApplicationHandler for App<W> {
             }
 
             WindowEvent::MouseInput { state, button, .. } => {
-                if button == MouseButton::Left {
-                    ui.set_mouse_pressed(state == ElementState::Pressed);
-                    ui.set_mouse_released(state == ElementState::Released);
+                match button {
+                    MouseButton::Left => {
+                        ui.set_mouse_pressed(state == ElementState::Pressed);
+                        ui.set_mouse_released(state == ElementState::Released);
+                    }
+                    MouseButton::Right => {
+                        ui.set_mouse_right_pressed(state == ElementState::Pressed);
+                        ui.set_mouse_right_released(state == ElementState::Released);
+                    }
+                    MouseButton::Middle => {
+                        ui.set_mouse_middle_pressed(state == ElementState::Pressed);
+                        ui.set_mouse_middle_released(state == ElementState::Released);
+                    }
+                    _ => {}
                 }
             }
 

--- a/src/radio_button.rs
+++ b/src/radio_button.rs
@@ -4,6 +4,7 @@ use crate::interaction::Interaction;
 use crate::theme::Theme;
 use crate::ui::Ui;
 use crate::widget::{Measurable, Widget};
+use winit::window::CursorIcon;
 
 #[derive(Debug, Clone, Copy)]
 pub struct RadioButtonResponse {
@@ -89,6 +90,10 @@ impl Measurable for RadioButton {
         let style = self.style.clone().unwrap_or_default();
         let interaction = Interaction::update(position, size, style.corner_radius, ui);
         self.interaction = interaction;
+
+        if interaction.hovered {
+            ui.set_cursor_icon(CursorIcon::Pointer);
+        }
 
         if interaction.clicked {
             ui.select(&self.group_id, &self.option_id);

--- a/src/scroll_view.rs
+++ b/src/scroll_view.rs
@@ -4,6 +4,7 @@ use crate::geometry::contains;
 use crate::scrolling::{ScrollAxisState, ScrollConfig, compute_geometry, handle_drag};
 use crate::ui::Ui;
 use crate::widget::{AnyWidget, Measurable, Widget};
+use winit::window::CursorIcon;
 
 #[derive(Default)]
 pub struct ScrollState {
@@ -181,6 +182,10 @@ impl<'a> Measurable for ScrollView<'a> {
         ) {
             state.x.offset = new_offset;
             state.x.mark_activity();
+        }
+
+        if thumb_hovered_x || thumb_hovered_y || state.x.dragging || state.y.dragging {
+            ui.set_cursor_icon(CursorIcon::Pointer);
         }
 
         // Clamp AFTER both wheel and drag have had a chance to move the

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -5,6 +5,7 @@ use crate::shadow::{ShadowStyle, draw_shadow};
 use crate::theme::Theme;
 use crate::ui::Ui;
 use crate::widget::{Measurable, Widget};
+use winit::window::CursorIcon;
 
 #[derive(Default)]
 pub struct SliderState {
@@ -97,7 +98,11 @@ impl Measurable for Slider {
             && !ui.is_input_blocked(mouse_pos)
             && ui.point_in_current_clip(mouse_pos);
 
-        let state = ui.widget_state::<SliderState>(&self.id);
+        let mut state = ui.take_widget_state::<SliderState>(&self.id);
+
+        if hovered || state.dragging {
+            ui.set_cursor_icon(CursorIcon::EwResize);
+        }
 
         let mut changed = false;
         if hovered && mouse_pressed_this_frame {
@@ -126,6 +131,7 @@ impl Measurable for Slider {
 
         let value = state.value;
         let dragging = state.dragging;
+        ui.put_widget_state(&self.id, state);
 
         // Visual layout
         let track_y = position[1] + (size[1] - style.track_height) / 2.0;

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -5,6 +5,7 @@ use crate::shadow::{ShadowStyle, draw_shadow};
 use crate::theme::Theme;
 use crate::ui::Ui;
 use crate::widget::{Measurable, Widget};
+use winit::window::CursorIcon;
 
 #[derive(Default)]
 pub struct SwitchState {
@@ -90,6 +91,10 @@ impl Measurable for Switch {
         let style = self.style.clone().unwrap_or_default();
         let interaction = Interaction::update(position, size, style.corner_radius, ui);
         self.interaction = interaction;
+
+        if interaction.hovered {
+            ui.set_cursor_icon(CursorIcon::Pointer);
+        }
 
         let state = ui.widget_state::<SwitchState>(&self.id);
         if interaction.clicked {

--- a/src/text_area.rs
+++ b/src/text_area.rs
@@ -8,6 +8,7 @@ use crate::theme::Theme;
 use crate::ui::Ui;
 use crate::widget::{FocusId, Measurable, Widget};
 use winit::keyboard::{Key, NamedKey};
+use winit::window::CursorIcon;
 
 #[derive(Default)]
 struct TextAreaExtra {
@@ -169,6 +170,10 @@ impl Measurable for TextArea {
             && contains(position, size, style.corner_radius, mouse_pos);
 
         let focused = self.focused(ui);
+
+        if hovered {
+            ui.set_cursor_icon(CursorIcon::Text);
+        }
 
         if ui.mouse_pressed_this_frame() && hovered {
             ui.request_focus(self.focus_id);

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -6,6 +6,7 @@ use crate::text_edit::TextEditState;
 use crate::theme::Theme;
 use crate::ui::Ui;
 use crate::widget::{FocusId, Measurable, Widget};
+use winit::window::CursorIcon;
 
 #[derive(Debug, Clone)]
 pub struct TextInputStyle {
@@ -105,6 +106,10 @@ impl Measurable for TextInput {
 
         let mut state = ui.take_widget_state::<TextEditState>(&self.id);
         state.hovered = hovered;
+
+        if hovered {
+            ui.set_cursor_icon(CursorIcon::Text);
+        }
 
         if ui.mouse_pressed_this_frame() && hovered {
             ui.request_focus(self.focus_id);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,13 +1,14 @@
 use crate::color::Color;
 use crate::fill::Fill;
 use crate::painter::Painter;
+use crate::theme::Theme;
 use crate::widget::{FocusId, Widget};
 use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
 use winit::keyboard::{Key, PhysicalKey};
-use winit::window::Window;
+use winit::window::{CursorIcon, Window};
 
 fn intersect_rects(a: [f32; 4], b: [f32; 4]) -> [f32; 4] {
     [
@@ -45,6 +46,17 @@ pub struct Ui {
     input_block_stack: Vec<[f32; 4]>,
     selected: HashMap<String, String>,
     click_count: u32,
+    cursor_icon: CursorIcon,
+    cursor_icon_set_this_frame: bool,
+    mouse_right_pressed: bool,
+    mouse_right_released: bool,
+    mouse_right_pressed_this_frame: bool,
+    mouse_right_released_this_frame: bool,
+    mouse_middle_pressed: bool,
+    mouse_middle_released: bool,
+    mouse_middle_pressed_this_frame: bool,
+    mouse_middle_released_this_frame: bool,
+    pending_tooltip: Option<(String, [f32; 2])>,
 }
 
 impl Ui {
@@ -82,6 +94,17 @@ impl Ui {
             input_block_stack: Vec::new(),
             selected: HashMap::new(),
             click_count: 0,
+            cursor_icon: CursorIcon::Default,
+            cursor_icon_set_this_frame: false,
+            mouse_right_pressed: false,
+            mouse_right_released: false,
+            mouse_right_pressed_this_frame: false,
+            mouse_right_released_this_frame: false,
+            mouse_middle_pressed: false,
+            mouse_middle_released: false,
+            mouse_middle_pressed_this_frame: false,
+            mouse_middle_released_this_frame: false,
+            pending_tooltip: None,
         }
     }
 
@@ -300,6 +323,76 @@ impl Ui {
         self.mouse_released = released;
     }
 
+    pub fn mouse_right_pressed(&self) -> bool {
+        self.mouse_right_pressed
+    }
+
+    pub fn mouse_right_released(&self) -> bool {
+        self.mouse_right_released
+    }
+
+    pub fn mouse_right_pressed_this_frame(&self) -> bool {
+        self.mouse_right_pressed_this_frame
+    }
+
+    pub fn mouse_right_released_this_frame(&self) -> bool {
+        self.mouse_right_released_this_frame
+    }
+
+    pub fn set_mouse_right_pressed(&mut self, pressed: bool) {
+        self.mouse_right_pressed_this_frame = pressed && !self.mouse_right_pressed;
+        self.mouse_right_pressed = pressed;
+    }
+
+    pub fn set_mouse_right_released(&mut self, released: bool) {
+        self.mouse_right_released_this_frame = released && !self.mouse_right_released;
+        self.mouse_right_released = released;
+    }
+
+    pub fn mouse_middle_pressed(&self) -> bool {
+        self.mouse_middle_pressed
+    }
+
+    pub fn mouse_middle_released(&self) -> bool {
+        self.mouse_middle_released
+    }
+
+    pub fn mouse_middle_pressed_this_frame(&self) -> bool {
+        self.mouse_middle_pressed_this_frame
+    }
+
+    pub fn mouse_middle_released_this_frame(&self) -> bool {
+        self.mouse_middle_released_this_frame
+    }
+
+    pub fn set_mouse_middle_pressed(&mut self, pressed: bool) {
+        self.mouse_middle_pressed_this_frame = pressed && !self.mouse_middle_pressed;
+        self.mouse_middle_pressed = pressed;
+    }
+
+    pub fn set_mouse_middle_released(&mut self, released: bool) {
+        self.mouse_middle_released_this_frame = released && !self.mouse_middle_released;
+        self.mouse_middle_released = released;
+    }
+
+    pub fn set_cursor_icon(&mut self, icon: CursorIcon) {
+        self.cursor_icon = icon;
+        self.cursor_icon_set_this_frame = true;
+        self.window.set_cursor(icon);
+    }
+
+    pub fn cursor_icon(&self) -> CursorIcon {
+        self.cursor_icon
+    }
+
+    pub fn show_tooltip(&mut self, text: impl Into<String>) {
+        self.pending_tooltip = Some((text.into(), self.mouse_position));
+    }
+
+    pub fn show_tooltip_at(&mut self, text: impl Into<String>, position: [f32; 2]) {
+        self.pending_tooltip = Some((text.into(), position));
+    }
+
     pub fn mouse_position(&self) -> [f32; 2] {
         self.mouse_position
     }
@@ -357,12 +450,23 @@ impl Ui {
     pub fn end_frame(&mut self) {
         self.mouse_pressed_this_frame = false;
         self.mouse_released_this_frame = false;
+        self.mouse_right_pressed_this_frame = false;
+        self.mouse_right_released_this_frame = false;
+        self.mouse_middle_pressed_this_frame = false;
+        self.mouse_middle_released_this_frame = false;
         self.typed_text.clear();
         self.keys_pressed_this_frame.clear();
         self.physical_keys_pressed_this_frame.clear();
         self.focus_requested_this_frame = false;
         self.scroll_delta_x = 0.0;
         self.scroll_delta_y = 0.0;
+
+        if !self.cursor_icon_set_this_frame && self.cursor_icon != CursorIcon::Default {
+            self.cursor_icon = CursorIcon::Default;
+            self.window.set_cursor(CursorIcon::Default);
+        }
+        self.cursor_icon_set_this_frame = false;
+        self.pending_tooltip = None;
     }
 
     pub fn line_height(&self) -> f32 {
@@ -418,6 +522,47 @@ impl Ui {
     }
 
     pub fn render(&mut self) {
+        if let Some((text, pos)) = self.pending_tooltip.take() {
+            let text_width = self.measure_text(&text);
+            let pad_x = 8.0;
+            let pad_y = 5.0;
+            let width = text_width + pad_x * 2.0;
+            let height = self.line_height() + pad_y * 2.0;
+
+            let window_size = self.painter.window_size();
+            let mut tooltip_pos = [pos[0] + 12.0, pos[1] + 18.0];
+            if tooltip_pos[0] + width > window_size[0] {
+                tooltip_pos[0] = (window_size[0] - width - 4.0).max(0.0);
+            }
+            if tooltip_pos[1] + height > window_size[1] {
+                tooltip_pos[1] = (pos[1] - height - 6.0).max(0.0);
+            }
+
+            let full_clip = [0.0, 0.0, window_size[0], window_size[1]];
+            self.painter.draw_rect(
+                tooltip_pos,
+                [width, height],
+                Fill::Solid(Theme::SURFACE_ELEVATED),
+                6.0,
+                1.0,
+                Theme::BORDER_STRONG,
+                8.0,
+                0.0,
+                full_clip,
+            );
+
+            self.painter.draw_text(
+                &text,
+                [tooltip_pos[0] + pad_x, tooltip_pos[1] + pad_y],
+                [
+                    tooltip_pos[0],
+                    tooltip_pos[1],
+                    tooltip_pos[0] + width,
+                    tooltip_pos[1] + height,
+                ],
+            );
+        }
+
         self.painter.present();
     }
 


### PR DESCRIPTION
Implement support for right and middle mouse buttons, and add cursor icon management for various widgets.

- Add right and middle mouse button state tracking in `Ui`
- Implement tooltip support for `Button`
- Add context-aware cursor icons (Pointer, Text, EwResize) for widgets
- Update `demo.rs` to use new tooltip functionality
- Add `CHANGELOG.md` and `CONTRIBUTING.md` documentation files